### PR TITLE
Fix missing English names for several wikis

### DIFF
--- a/generation/wikis.ipynb
+++ b/generation/wikis.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -96,7 +96,7 @@
        "Index: []"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -108,7 +108,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,7 +175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -193,7 +193,7 @@
        " 'tay'}"
       ]
      },
-     "execution_count": 52,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -206,7 +206,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -237,7 +237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -269,7 +269,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -296,11 +296,77 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
-    "wikis = wikis.merge(project_names, on=\"database_code\")"
+    "wikis = wikis.merge(project_names, on=\"database_code\", how=\"left\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['arbcom_cswiki',\n",
+       " 'dtywiki',\n",
+       " 'electcomwiki',\n",
+       " 'hiwikimedia',\n",
+       " 'pawikisource',\n",
+       " 'projectcomwiki',\n",
+       " 'ptwikimedia',\n",
+       " 'romdwikimedia',\n",
+       " 'techconductwiki',\n",
+       " 'testcommonswiki',\n",
+       " 'wbwikimedia',\n",
+       " 'yuewiktionary']"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Check for wikis with null English names since some might not be included in WikimediaMessages' en.json\n",
+    "null_name_wikis = wikis[wikis[\"english_name\"].isna()].copy()\n",
+    "null_name_wikis.index.tolist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add missing English names. Remove manual additions once no longer needed. \n",
+    "extra_names = {\n",
+    "    \"arbcom_cswiki\" : \"Czech Wikipedia Arbitration Committee\",\n",
+    "    'dtywiki' : \"Doteli Wikipedia\",\n",
+    "    'electcomwiki' : \"Wikimedia Foundation Elections Committee\",\n",
+    "    'hiwikimedia' : \"Hindi Wikimedians User Group\",\n",
+    "    'pawikisource' : \"Punjabi Wikisource\",\n",
+    "    'projectcomwiki' : \"Project Grants Committee\",\n",
+    "    'ptwikimedia' : \"Wikimedia Portugal\",\n",
+    "    'romdwikimedia' : \"Wikimedians of Romania and Moldova User Group\",\n",
+    "    'techconductwiki' : \"Code of Conduct Committee\",\n",
+    "    'testcommonswiki' : \"Commons Test Wiki\",\n",
+    "    'wbwikimedia' : \"West Bengal Wikimedians User Group \",\n",
+    "    'yuewiktionary' : \"Cantonese Wiktionary\"\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "null_name_wikis[\"english_name\"] = null_name_wikis.index.map(extra_names.get)\n",
+    "wikis.update(null_name_wikis, overwrite=False)"
    ]
   },
   {
@@ -312,7 +378,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -322,7 +388,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -336,7 +402,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.11"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/generation/wikis.ipynb
+++ b/generation/wikis.ipynb
@@ -337,6 +337,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "How do we figure out what to name wikis for which we do not have names?\n",
+    "\n",
+    "1. The type of the wiki might be identifiable through the database code. For example, all Wikipedia wikis end with `wiki`, and and all affiliate and user group wikis end with `wikimedia`. For Wikipedias, there's the [List of Wikipedias](https://meta.wikimedia.org/wiki/List_of_Wikipedias), and for other wikis there's the [Complete list of Wikimedia projects](https://meta.wikimedia.org/wiki/Special:MyLanguage/Complete_list_of_Wikimedia_projects).\n",
+    "2. Chapter, user group, and affiliate wikis tend to be named in either a way that ends with \"Wikimedians User Group\", or named after a country (e.g. \"Wikimedia Portugal\"). Visiting the wiki and using translation services can give an idea of what the name is, and some of these wikis are in English.\n",
+    "3. Committee wikis might have a database code that ends with `comwiki`. Again, finding the wikis URL and visiting it can give an idea of what the name is.\n",
+    "4. For most of these there are already existing wikis in the list, so querying it will give you an idea of what the naming scheme is."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 13,
    "metadata": {},

--- a/wikis.csv
+++ b/wikis.csv
@@ -30,6 +30,7 @@ angwiktionary,ang.wiktionary.org,wiktionary,ang,Old English,open,public,public,O
 anwiki,an.wikipedia.org,wikipedia,an,Aragonese,open,public,public,Aragonese Wikipedia
 anwiktionary,an.wiktionary.org,wiktionary,an,Aragonese,open,public,public,Aragonese Wiktionary
 apiportalwiki,api.wikimedia.org,apiportal,en,English,open,public,public,Wikimedia Api Portal
+arbcom_cswiki,arbcom-cs.wikipedia.org,arbcom-cs,en,English,open,private,private,Czech Wikipedia Arbitration Committee
 arbcom_dewiki,arbcom-de.wikipedia.org,arbcom-de,en,English,open,private,private,German Wikipedia Arbitration Committee
 arbcom_enwiki,arbcom-en.wikipedia.org,arbcom-en,en,English,open,private,private,English Wikipedia Arbitration Committee
 arbcom_fiwiki,arbcom-fi.wikipedia.org,arbcom-fi,en,English,open,private,private,Finnish Wikipedia Arbitration Committee
@@ -197,12 +198,14 @@ diqwiktionary,diq.wiktionary.org,wiktionary,diq,Zazaki,open,public,public,Zazaki
 dkwikimedia,dk.wikimedia.org,dkwikimedia,en,English,open,public,public,Wikimedia Denmark
 donatewiki,donate.wikimedia.org,donate,en,English,open,public,private,Donate
 dsbwiki,dsb.wikipedia.org,wikipedia,dsb,Lower Sorbian,open,public,public,Lower Sorbian Wikipedia
+dtywiki,dty.wikipedia.org,wikipedia,dty,Doteli,open,public,public,Doteli Wikipedia
 dvwiki,dv.wikipedia.org,wikipedia,dv,Divehi,open,public,public,Divehi Wikipedia
 dvwiktionary,dv.wiktionary.org,wiktionary,dv,Divehi,open,public,public,Divehi Wiktionary
 dzwiki,dz.wikipedia.org,wikipedia,dz,Dzongkha,open,public,public,Dzongkha Wikipedia
 dzwiktionary,dz.wiktionary.org,wiktionary,dz,Dzongkha,closed,public,public,Dzongkha Wiktionary
 ecwikimedia,ec.wikimedia.org,ecwikimedia,en,English,open,private,private,Wikimedistas de Ecuador
 eewiki,ee.wikipedia.org,wikipedia,ee,Ewe,open,public,public,Ewe Wikipedia
+electcomwiki,electcom.wikimedia.org,electcom,en,English,open,private,private,Wikimedia Foundation Elections Committee
 elwiki,el.wikipedia.org,wikipedia,el,Greek,open,public,public,Greek Wikipedia
 elwikibooks,el.wikibooks.org,wikibooks,el,Greek,open,public,public,Greek Wikibooks
 elwikinews,el.wikinews.org,wikinews,el,Greek,open,public,public,Greek Wikinews
@@ -318,6 +321,7 @@ guwikibooks,gu.wikibooks.org,wikibooks,gu,Gujarati,closed,public,public,Gujarati
 guwikiquote,gu.wikiquote.org,wikiquote,gu,Gujarati,open,public,public,Gujarati Wikiquote
 guwikisource,gu.wikisource.org,wikisource,gu,Gujarati,open,public,public,Gujarati Wikisource
 guwiktionary,gu.wiktionary.org,wiktionary,gu,Gujarati,open,public,public,Gujarati Wiktionary
+guwwiki,guw.wikipedia.org,wikipedia,guw,Gun,open,public,public,Gun Wikipedia
 gvwiki,gv.wikipedia.org,wikipedia,gv,Manx,open,public,public,Manx Wikipedia
 gvwiktionary,gv.wiktionary.org,wiktionary,gv,Manx,open,public,public,Manx Wiktionary
 hakwiki,hak.wikipedia.org,wikipedia,hak,Hakka Chinese,open,public,public,Hakka Chinese Wikipedia
@@ -335,6 +339,7 @@ hifwiki,hif.wikipedia.org,wikipedia,hif,Fiji Hindi,open,public,public,Fiji Hindi
 hifwiktionary,hif.wiktionary.org,wiktionary,hif,Fiji Hindi,open,public,public,Fiji Hindi Wiktionary
 hiwiki,hi.wikipedia.org,wikipedia,hi,Hindi,open,public,public,Hindi Wikipedia
 hiwikibooks,hi.wikibooks.org,wikibooks,hi,Hindi,open,public,public,Hindi Wikibooks
+hiwikimedia,hi.wikimedia.org,hiwikimedia,en,English,open,public,private,Hindi Wikimedians User Group
 hiwikiquote,hi.wikiquote.org,wikiquote,hi,Hindi,open,public,public,Hindi Wikiquote
 hiwikisource,hi.wikisource.org,wikisource,hi,Hindi,open,public,public,Hindi Wikisource
 hiwikiversity,hi.wikiversity.org,wikiversity,hi,Hindi,open,public,public,Hindi Wikiversity
@@ -624,7 +629,7 @@ ocwikibooks,oc.wikibooks.org,wikibooks,oc,Occitan,open,public,public,Occitan Wik
 ocwiktionary,oc.wiktionary.org,wiktionary,oc,Occitan,open,public,public,Occitan Wiktionary
 officewiki,office.wikimedia.org,office,en,English,open,private,private,Wikimedia Office
 olowiki,olo.wikipedia.org,wikipedia,olo,Livvi-Karelian,open,public,public,Livvi-Karelian Wikipedia
-ombudsmenwiki,ombudsmen.wikimedia.org,ombudsmen,en,English,open,private,private,Ombudsmen Wiki
+ombudsmenwiki,ombuds.wikimedia.org,ombudsmen,en,English,open,private,private,Ombuds Wiki
 omwiki,om.wikipedia.org,wikipedia,om,Oromo,open,public,public,Oromo Wikipedia
 omwiktionary,om.wiktionary.org,wiktionary,om,Oromo,open,public,public,Oromo Wiktionary
 orwiki,or.wikipedia.org,wikipedia,or,Odia,open,public,public,Oriya Wikipedia
@@ -639,6 +644,7 @@ pamwiki,pam.wikipedia.org,wikipedia,pam,Pampanga,open,public,public,Pampanga Wik
 papwiki,pap.wikipedia.org,wikipedia,pap,Papiamento,open,public,public,Papiamento Wikipedia
 pawiki,pa.wikipedia.org,wikipedia,pa,Punjabi,open,public,public,Punjabi Wikipedia
 pawikibooks,pa.wikibooks.org,wikibooks,pa,Punjabi,open,public,public,Punjabi Wikibooks
+pawikisource,pa.wikisource.org,wikisource,pa,Punjabi,open,public,public,Punjabi Wikisource
 pawiktionary,pa.wiktionary.org,wiktionary,pa,Punjabi,open,public,public,Punjabi Wiktionary
 pcdwiki,pcd.wikipedia.org,wikipedia,pcd,Picard,open,public,public,Picard Wikipedia
 pdcwiki,pdc.wikipedia.org,wikipedia,pdc,Pennsylvania German,open,public,public,Pennsylvania German Wikipedia
@@ -659,12 +665,14 @@ pmswikisource,pms.wikisource.org,wikisource,pms,Piedmontese,open,public,public,P
 pnbwiki,pnb.wikipedia.org,wikipedia,pnb,Western Punjabi,open,public,public,Western Punjabi Wikipedia
 pnbwiktionary,pnb.wiktionary.org,wiktionary,pnb,Western Punjabi,open,public,public,Western Punjabi Wiktionary
 pntwiki,pnt.wikipedia.org,wikipedia,pnt,Pontic,open,public,public,Pontic Wikipedia
+projectcomwiki,projectcom.wikimedia.org,projectcom,en,English,open,private,private,Project Grants Committee
 pswiki,ps.wikipedia.org,wikipedia,ps,Pashto,open,public,public,Pashto Wikipedia
 pswikibooks,ps.wikibooks.org,wikibooks,ps,Pashto,closed,public,public,Pashto Wikibooks
 pswikivoyage,ps.wikivoyage.org,wikivoyage,ps,Pashto,open,public,public,Pashto Wikivoyage
 pswiktionary,ps.wiktionary.org,wiktionary,ps,Pashto,open,public,public,Pashto Wiktionary
 ptwiki,pt.wikipedia.org,wikipedia,pt,Portuguese,open,public,public,Portuguese Wikipedia
 ptwikibooks,pt.wikibooks.org,wikibooks,pt,Portuguese,open,public,public,Portuguese Wikibooks
+ptwikimedia,pt.wikimedia.org,ptwikimedia,en,English,open,public,public,Wikimedia Portugal
 ptwikinews,pt.wikinews.org,wikinews,pt,Portuguese,open,public,public,Portuguese Wikinews
 ptwikiquote,pt.wikiquote.org,wikiquote,pt,Portuguese,open,public,public,Portuguese Wikiquote
 ptwikisource,pt.wikisource.org,wikisource,pt,Portuguese,open,public,public,Portuguese Wikisource
@@ -687,6 +695,7 @@ rnwiktionary,rn.wiktionary.org,wiktionary,rn,Rundi,closed,public,public,Rundi Wi
 roa_rupwiki,roa-rup.wikipedia.org,wikipedia,roa-rup,Aromanian,open,public,public,Aromanian Wikipedia
 roa_rupwiktionary,roa-rup.wiktionary.org,wiktionary,roa-rup,Aromanian,open,public,public,Aromanian Wiktionary
 roa_tarawiki,roa-tara.wikipedia.org,wikipedia,roa-tara,Tarantino,open,public,public,Tarandíne Wikipedia
+romdwikimedia,romd.wikimedia.org,romdwikimedia,en,English,open,public,private,Wikimedians of Romania and Moldova User Group
 rowiki,ro.wikipedia.org,wikipedia,ro,Romanian,open,public,public,Romanian Wikipedia
 rowikibooks,ro.wikibooks.org,wikibooks,ro,Romanian,open,public,public,Romanian Wikibooks
 rowikinews,ro.wikinews.org,wikinews,ro,Romanian,open,public,public,Romanian Wikinews
@@ -732,6 +741,7 @@ sgwiki,sg.wikipedia.org,wikipedia,sg,Sango,open,public,public,Sango Wikipedia
 sgwiktionary,sg.wiktionary.org,wiktionary,sg,Sango,open,public,public,Sango Wiktionary
 shiwiki,shi.wikipedia.org,wikipedia,shi,Tachelhit,open,public,public,Tachelhit Wikipedia
 shnwiki,shn.wikipedia.org,wikipedia,shn,Shan,open,public,public,Shan Wikipedia
+shnwikivoyage,shn.wikivoyage.org,wikivoyage,shn,Shan,open,public,public,Shan Wikivoyage
 shnwiktionary,shn.wiktionary.org,wiktionary,shn,Shan,open,public,public,Shan Wiktionary
 shwiki,sh.wikipedia.org,wikipedia,sh,Serbo-Croatian,open,public,public,Serbo-Croatian Wikipedia
 shwiktionary,sh.wiktionary.org,wiktionary,sh,Serbo-Croatian,open,public,public,Serbo-Croatian Wiktionary
@@ -811,8 +821,10 @@ tawikisource,ta.wikisource.org,wikisource,ta,Tamil,open,public,public,Tamil Wiki
 tawiktionary,ta.wiktionary.org,wiktionary,ta,Tamil,open,public,public,Tamil Wiktionary
 taywiki,tay.wikipedia.org,wikipedia,tay,Atayal,open,public,public,Atayal Wikipedia
 tcywiki,tcy.wikipedia.org,wikipedia,tcy,Tulu,open,public,public,Tulu Wikipedia
+techconductwiki,techconduct.wikimedia.org,techconduct,en,English,open,private,private,Code of Conduct Committee
 tenwiki,ten.wikipedia.org,ten,en,English,closed,public,public,Wikipedia 10
 test2wiki,test2.wikipedia.org,test2,en,English,open,public,public,Test2 Wikipedia
+testcommonswiki,test-commons.wikimedia.org,testcommons,en,English,open,public,public,Commons Test Wiki
 testwiki,test.wikipedia.org,test,en,English,open,public,public,Test Wikipedia
 testwikidatawiki,test.wikidata.org,testwikidata,en,English,open,public,public,Wikidata Test Wiki
 tetwiki,tet.wikipedia.org,wikipedia,tet,Tetum,open,public,public,Tetum Wikipedia
@@ -911,6 +923,7 @@ wawiki,wa.wikipedia.org,wikipedia,wa,Walloon,open,public,public,Walloon Wikipedi
 wawikibooks,wa.wikibooks.org,wikibooks,wa,Walloon,closed,public,public,Walloon Wikibooks
 wawikisource,wa.wikisource.org,wikisource,wa,Walloon,open,public,public,Walloon Wikisource
 wawiktionary,wa.wiktionary.org,wiktionary,wa,Walloon,open,public,public,Walloon Wiktionary
+wbwikimedia,wb.wikimedia.org,wbwikimedia,en,English,open,public,private,West Bengal Wikimedians User Group 
 wg_enwiki,wg-en.wikipedia.org,wg-en,en,English,open,private,private,English Wikipedia Working Group
 wikidatawiki,www.wikidata.org,wikidata,en,English,open,public,public,Wikidata
 wikimania2005wiki,wikimania2005.wikimedia.org,wikimania2005,en,English,closed,public,public,Wikimania 2005 Wiki
@@ -944,6 +957,7 @@ yiwiktionary,yi.wiktionary.org,wiktionary,yi,Yiddish,open,public,public,Yiddish 
 yowiki,yo.wikipedia.org,wikipedia,yo,Yoruba,open,public,public,Yoruba Wikipedia
 yowikibooks,yo.wikibooks.org,wikibooks,yo,Yoruba,closed,public,public,Yoruba Wikibooks
 yowiktionary,yo.wiktionary.org,wiktionary,yo,Yoruba,closed,public,public,Yoruba Wiktionary
+yuewiktionary,yue.wiktionary.org,wiktionary,yue,Cantonese,open,public,public,Cantonese Wiktionary
 zawiki,za.wikipedia.org,wikipedia,za,Zhuang,open,public,public,Zhuang Wikipedia
 zawikibooks,za.wikibooks.org,wikibooks,za,Zhuang,closed,public,public,Zhuang Wikibooks
 zawikiquote,za.wikiquote.org,wikiquote,za,Zhuang,closed,public,public,Zhuang Wikiquote


### PR DESCRIPTION
Wikis that are not found in WikimediaMessages list of English
names are no longer discarded. We instead list them out and
create a mapping of database codes to names, which is then used
to update the dataset.

Fixes #1